### PR TITLE
Switch markdown parser to PegDown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+*.iml
+.idea

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,16 @@
+# Changelog for markdown2html
+
+## Version 1.1-SNAPSHOT
+Date: 2015-11-20
+
+* Changed parser from [MarkdownJ](https://github.com/myabc/markdownj) to [Pegdown](https://github.com/sirthias/pegdown)
+* Pegdown supports full GitHub flavored MD
+* Requires Java1.8
+* Increased Application window size
+* Much better HTML preview rendering by using `JFXPane` component from JavaFX
+* Added Github like CSS style sheet for the preview
+* Support for Undo/Redo in the editor (Ctrl-Z/Ctrl-Y for Windows, Command-Z/Shift-Command-Z for OSX)
+
+## Version 1.0-SNAPSHOT
+Original version from [Nilhcem](https://github.com/Nilhcem/markdown2html) with support
+for plain Markdown syntax.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 Markdown2HTML
 =============
 
-An extremely simple Markdown to HTML converter,
-powered by [Pegdown](https://github.com/vsch/pegdown)
+A powerful Markdown to HTML converter, powered by [Pegdown](https://github.com/vsch/pegdown)
 
 Available in command line and GUI mode.
 
-It is licensed under the BSD license.
+Licensed under the BSD license.
 
 
 Requirements
@@ -44,12 +43,18 @@ Refer to the [Pegdown project](https://github.com/vsch/pegdown) for details abou
 supported markdown features. It basically supports full standard markdown
 plus a bunch of extensions, including tables, definition lists etc, as found 
 in [Github flavoured MarkDown](https://help.github.com/articles/github-flavored-markdown/).
+Includes CSS style sheet for a GitHub-like look.
 
 GUI Screenshot
 --------------
 
 <img src="http://nilhcem.github.com/screenshots/markdown2html.png" width="814" height="564" />
 
+
+Versions
+--------
+Latest version: 1.1-SNAPSHOT
+See [change log](CHANGES.md)
 
 Building it
 -----------

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Markdown2HTML
 =============
 
 An extremely simple Markdown to HTML converter,
-powered by [MarkdownJ](http://code.google.com/p/markdownj/).
+powered by [Pegdown](https://github.com/vsch/pegdown)
 
 Available in command line and GUI mode.
 
@@ -12,7 +12,7 @@ It is licensed under the BSD license.
 Requirements
 ------------
 
-You need Java JVM 1.6 or newer installed on your machine.
+You need Java JVM 1.8 or newer installed on your machine.
 
 
 Usage
@@ -37,6 +37,13 @@ Its content will be appended to the converted `markdownFile` file.
 which contains the same name as the `markdownFile`, with the .html extension.
 - `-out file.html`: enter this to specify the name of the converted file.
 - `-d directory`: enter this to specify the directory of the converted files.
+
+Markdown support
+----------------
+Refer to the [Pegdown project](https://github.com/vsch/pegdown) for details about 
+supported markdown features. It basically supports full standard markdown
+plus a bunch of extensions, including tables, definition lists etc, as found 
+in [Github flavoured MarkDown](https://help.github.com/articles/github-flavored-markdown/).
 
 GUI Screenshot
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+				 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.nilhcem</groupId>
 	<artifactId>markdown2html</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>markdown2html</name>
@@ -23,21 +23,6 @@
 			<classifier>swing</classifier>
 		</dependency>
 
-		<!-- MarkdownJ -->
-		<!--
-		<dependency>
-			<groupId>org.markdownj</groupId>
-			<artifactId>markdownj</artifactId>
-			<version>0.3.0-1.0.2b4</version>
-		</dependency>
-		-->
-		
-<dependency>
-  <groupId>org.markdownj</groupId>
-  <artifactId>markdownj-core</artifactId>
-  <version>0.4</version>
-</dependency>		
-		
 
 		<!-- Commons IO: utilities to assist with developing IO functionality -->
 		<dependency>
@@ -45,20 +30,25 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.0.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.pegdown</groupId>
+			<artifactId>pegdown</artifactId>
+			<version>1.4.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>
 		<finalName>Markdown2HTML-${project.version}</finalName>
 
 		<plugins>
-			<!-- Use JDK 1.6 -->
+			<!-- Use JDK 1.8 -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 
@@ -66,7 +56,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.2.1</version>
+				<version>2.5.5</version>
 				<configuration>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
@@ -101,6 +91,14 @@
 			</roles>
 			<timezone>+8</timezone>
 		</developer>
+		<developer>
+			<id>janhoy</id>
+			<name>Jan Høydahl</name>
+			<roles>
+				<role>developer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
 	</developers>
 
 	<!-- License -->
@@ -110,12 +108,4 @@
 			<url>LICENSE.txt</url>
 		</license>
 	</licenses>
-
-	<repositories>
-		<!-- MarkdownJ repository -->
-		<repository>
-			<id>scala-tools</id>
-			<url>http://scala-tools.org/repo-releases</url>
-		</repository>
-	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.pegdown</groupId>
 			<artifactId>pegdown</artifactId>
-			<version>1.4.1</version>
+			<version>1.6.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/nilhcem/md2html/App.java
+++ b/src/main/java/com/nilhcem/md2html/App.java
@@ -1,6 +1,7 @@
 package com.nilhcem.md2html;
 
 import java.awt.EventQueue;
+import java.io.File;
 import java.io.FileNotFoundException;
 import javax.swing.UIManager;
 import com.nilhcem.md2html.console.ArgsParser;
@@ -32,7 +33,6 @@ public final class App {
 				if(args[i].equals("-d")){
 					idxDir = i+1;
 				}
-				//System.out.println(args[i]);
 			}
 			
 			if(idxDir>0){

--- a/src/main/java/com/nilhcem/md2html/App.java
+++ b/src/main/java/com/nilhcem/md2html/App.java
@@ -8,6 +8,7 @@ import com.nilhcem.md2html.console.ArgsParser;
 import com.nilhcem.md2html.console.ConsoleMode;
 import com.nilhcem.md2html.console.DisplayUsageException;
 import com.nilhcem.md2html.gui.MainFrame;
+import org.pegdown.Extensions;
 
 /**
  * Entry point of the application.
@@ -16,6 +17,21 @@ import com.nilhcem.md2html.gui.MainFrame;
  * @since 1.0
  */
 public final class App {
+	public static int pegdownOptions =
+			Extensions.ABBREVIATIONS
+			| Extensions.ATXHEADERSPACE
+			| Extensions.AUTOLINKS
+			| Extensions.DEFINITIONS
+			| Extensions.EXTANCHORLINKS
+			| Extensions.FENCED_CODE_BLOCKS
+			| Extensions.FORCELISTITEMPARA
+			| Extensions.HARDWRAPS
+			| Extensions.RELAXEDHRULES
+			| Extensions.SMARTS
+			| Extensions.STRIKETHROUGH
+			| Extensions.TABLES
+			| Extensions.TASKLISTITEMS;
+
 	private App() {}
 
 	/**
@@ -57,21 +73,18 @@ public final class App {
 			if (params.isConsoleMode()) { // Command line
 				new ConsoleMode().process(params);
 			} else { // GUI
-				EventQueue.invokeLater(new Runnable() {
-					@Override
-					public void run() {
-						System.setProperty("apple.laf.useScreenMenuBar", "true");
-						System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Markdown editor");
-						UIManager.put("swing.boldMetal", Boolean.FALSE);
-						try {
-							UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-						} catch (Exception e) {
-							System.err.println("error: " + e.getMessage());
-							e.printStackTrace();
-						}
-						new MainFrame();
-					}
-				});
+				EventQueue.invokeLater(() -> {
+                    System.setProperty("apple.laf.useScreenMenuBar", "true");
+                    System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Markdown editor");
+                    UIManager.put("swing.boldMetal", Boolean.FALSE);
+                    try {
+                        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+                    } catch (Exception e) {
+                        System.err.println("error: " + e.getMessage());
+                        e.printStackTrace();
+                    }
+                    new MainFrame();
+                });
 			}
 		} catch (DisplayUsageException e) {
 			System.err.println(e.getMessage());

--- a/src/main/java/com/nilhcem/md2html/DoDir.java
+++ b/src/main/java/com/nilhcem/md2html/DoDir.java
@@ -2,6 +2,7 @@ package com.nilhcem.md2html;
 
 import java.io.File;
 
+import com.nilhcem.md2html.console.ArgsParser;
 import org.apache.commons.io.FilenameUtils;
 
 import com.nilhcem.md2html.console.ConsoleMode;
@@ -39,7 +40,12 @@ public class DoDir {
 				
 				System.out.println( "doM2h:" + files[i].getAbsolutePath());
 				try {
-					cm.process(files[i], new File(strOutputFile));
+					// Not tested change
+					ArgsParser ap = new ArgsParser();
+					String[] args = {""};
+					args[0] = files[i].getAbsolutePath();
+					ap.checkArgs(args);
+					cm.process(ap);
 					errFile.deleteOnExit();
 					System.out.println( "del errFile:" + errFile.getAbsolutePath());
 				} catch (Exception e) {

--- a/src/main/java/com/nilhcem/md2html/console/ConsoleMode.java
+++ b/src/main/java/com/nilhcem/md2html/console/ConsoleMode.java
@@ -4,7 +4,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
-import com.petebevin.markdown.MarkdownProcessor;
+import org.pegdown.PegDownProcessor;
+import org.pegdown.Extensions;
 
 /**
  * Converts the markdown file in a HTML file when the application is running in command line.
@@ -13,7 +14,7 @@ import com.petebevin.markdown.MarkdownProcessor;
  * @since 1.0
  */
 public final class ConsoleMode {
-	private final MarkdownProcessor processor = new MarkdownProcessor();
+	private PegDownProcessor processor;
 
 	/**
 	 * Converts the file in HTML depending on the options sent in parameter.
@@ -28,8 +29,9 @@ public final class ConsoleMode {
 		}
 
 		try {
+			processor = new PegDownProcessor(Extensions.ALL);
 			String fileContent = FileUtils.readFileToString(file, "UTF-8");
-			String htmlContent = getFileContent(args.getHeaderFile()) + processor.markdown(fileContent) + getFileContent(args.getFooterFile());
+			String htmlContent = getFileContent(args.getHeaderFile()) + processor.markdownToHtml(fileContent) + getFileContent(args.getFooterFile());
 
 			if (args.getOutputFile() == null) {
 				// Display to console

--- a/src/main/java/com/nilhcem/md2html/console/ConsoleMode.java
+++ b/src/main/java/com/nilhcem/md2html/console/ConsoleMode.java
@@ -1,11 +1,12 @@
 package com.nilhcem.md2html.console;
 
+import com.nilhcem.md2html.App;
+import org.apache.commons.io.FileUtils;
+import org.pegdown.PegDownProcessor;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import org.apache.commons.io.FileUtils;
-import org.pegdown.PegDownProcessor;
-import org.pegdown.Extensions;
 
 /**
  * Converts the markdown file in a HTML file when the application is running in command line.
@@ -14,7 +15,6 @@ import org.pegdown.Extensions;
  * @since 1.0
  */
 public final class ConsoleMode {
-	private PegDownProcessor processor;
 
 	/**
 	 * Converts the file in HTML depending on the options sent in parameter.
@@ -29,7 +29,7 @@ public final class ConsoleMode {
 		}
 
 		try {
-			processor = new PegDownProcessor(Extensions.ALL);
+			PegDownProcessor processor = new PegDownProcessor(App.pegdownOptions);
 			String fileContent = FileUtils.readFileToString(file, "UTF-8");
 			String htmlContent = getFileContent(args.getHeaderFile()) + processor.markdownToHtml(fileContent) + getFileContent(args.getFooterFile());
 

--- a/src/main/java/com/nilhcem/md2html/gui/InputPane.java
+++ b/src/main/java/com/nilhcem/md2html/gui/InputPane.java
@@ -1,15 +1,21 @@
 package com.nilhcem.md2html.gui;
 
+import javax.swing.*;
+import javax.swing.text.Document;
+import javax.swing.undo.CannotRedoException;
+import javax.swing.undo.CannotUndoException;
+import javax.swing.undo.UndoManager;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.util.Observable;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
 
 /**
- * Scrolled text area where will be inputed markdown data to be converted.
+ * Scrolled text area where will be inpute markdown data to be converted.
+ * Also got Undo/redo support
  *
  * @author Nilhcem
+ * @author janhoy
  * @since 1.0
  */
 public final class InputPane extends Observable {
@@ -21,6 +27,47 @@ public final class InputPane extends Observable {
 	 */
 	public InputPane() {
 		inputPane.getViewport().add(inputTextArea, null);
+
+		final UndoManager undo = new UndoManager();
+		Document doc = inputTextArea.getDocument();
+
+		// Listen for undo and redo events
+		doc.addUndoableEditListener(evt -> undo.addEdit(evt.getEdit()));
+
+		// Create an undo action and add it to the text component
+		inputTextArea.getActionMap().put("Undo",
+		    new AbstractAction("Undo") {
+		        public void actionPerformed(ActionEvent evt) {
+		            try {
+		                if (undo.canUndo()) {
+		                    undo.undo();
+		                }
+		            } catch (CannotUndoException ignored) {
+		            }
+		        }
+		   });
+
+		// Bind the undo action to ctl-Z
+		inputTextArea.getInputMap().put(KeyStroke.getKeyStroke("control Z"), "Undo");
+		inputTextArea.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Z, KeyEvent.META_DOWN_MASK), "Undo");
+
+		// Create a redo action and add it to the text component
+		inputTextArea.getActionMap().put("Redo",
+		    new AbstractAction("Redo") {
+		        public void actionPerformed(ActionEvent evt) {
+		            try {
+		                if (undo.canRedo()) {
+		                    undo.redo();
+		                }
+		            } catch (CannotRedoException ignored) {
+		            }
+		        }
+		    });
+
+		// Bind the redo action to ctl-Y
+		inputTextArea.getInputMap().put(KeyStroke.getKeyStroke("control Y"), "Redo");
+		inputTextArea.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Z, KeyEvent.META_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK), "Redo");
+
 		inputTextArea.addKeyListener(new KeyListener() {
 			@Override
 			public void keyTyped(KeyEvent e) {

--- a/src/main/java/com/nilhcem/md2html/gui/MainFrame.java
+++ b/src/main/java/com/nilhcem/md2html/gui/MainFrame.java
@@ -1,7 +1,7 @@
 package com.nilhcem.md2html.gui;
 
 import java.awt.Dimension;
-import javax.swing.JFrame;
+import javax.swing.*;
 
 /**
  * Provides the main window of the application.
@@ -10,21 +10,21 @@ import javax.swing.JFrame;
  * @since 1.0
  */
 public final class MainFrame {
-	private final JFrame mainFrame = new JFrame("Markdown editor");
-	private final MenuBar menu = new MenuBar();
-	private final MainPanel panel = new MainPanel();
 
 	/**
 	 * Creates the main window and makes it visible.
 	 */
 	public MainFrame() {
-		Dimension frameSize = new Dimension(640, 440);
+		Dimension frameSize = new Dimension(900, 500);
 
-		mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		JFrame mainFrame = new JFrame("Markdown editor");
+		mainFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 		mainFrame.setSize(frameSize);
 		mainFrame.setMinimumSize(frameSize);
 
+		MenuBar menu = new MenuBar();
 		mainFrame.setJMenuBar(menu.get());
+		MainPanel panel = new MainPanel();
 		mainFrame.getContentPane().add(panel.get());
 		mainFrame.setLocationRelativeTo(null); // Center main frame
 		mainFrame.setVisible(true);

--- a/src/main/java/com/nilhcem/md2html/gui/MainPanel.java
+++ b/src/main/java/com/nilhcem/md2html/gui/MainPanel.java
@@ -1,6 +1,7 @@
 package com.nilhcem.md2html.gui;
 
 import javax.swing.JPanel;
+
 import net.miginfocom.swing.MigLayout;
 
 /**
@@ -16,14 +17,13 @@ public final class MainPanel {
 		"[grow,fill]"); // Row constraints
 	private final JPanel mainPanel = new JPanel(layout);
 
-	private final InputPane input = new InputPane();
-	private final PreviewPane preview = new PreviewPane();
-
 	/**
 	 * Creates the main panel, adding observer to the input and building the GUI.
 	 */
 	public MainPanel() {
 		// Add observer
+		InputPane input = new InputPane();
+		PreviewPane preview = new PreviewPane();
 		input.addObserver(preview);
 
 		// Build GUI

--- a/src/main/java/com/nilhcem/md2html/gui/MenuBar.java
+++ b/src/main/java/com/nilhcem/md2html/gui/MenuBar.java
@@ -1,12 +1,7 @@
 package com.nilhcem.md2html.gui;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import javax.swing.*;
 import java.util.Observable;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
 
 /**
  * Provides the menu bar of the application.
@@ -48,12 +43,7 @@ public final class MenuBar extends Observable {
 
 		JMenuItem exit = new JMenuItem("Exit");
 		exit.setMnemonic('x');
-		exit.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				System.exit(0);
-			}
-		});
+		exit.addActionListener(e -> System.exit(0));
 
 		fileMenu.add(exit);
 		return fileMenu;
@@ -73,14 +63,9 @@ public final class MenuBar extends Observable {
 
 		JMenuItem about = new JMenuItem("About");
 		about.setMnemonic('a');
-		about.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				JOptionPane.showMessageDialog(menuBar.getParent(),
-					String.format("Extremely simple Markdown to HTML converter%nPowered by MarkdownJ%nhttps://github.com/nilhcem"),
-					"Markdown2HTML: About", JOptionPane.INFORMATION_MESSAGE);
-			}
-		});
+		about.addActionListener(e -> JOptionPane.showMessageDialog(menuBar.getParent(),
+            String.format("Extremely simple Markdown to HTML converter%nPowered by MarkdownJ%nhttps://github.com/nilhcem"),
+            "Markdown2HTML: About", JOptionPane.INFORMATION_MESSAGE));
 
 		helpMenu.add(about);
 		return helpMenu;

--- a/src/main/resources/github-markdown.css
+++ b/src/main/resources/github-markdown.css
@@ -1,0 +1,168 @@
+/**
+ * markdown.css
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see http://gnu.org/licenses/lgpl.txt.
+ *
+ * @project      Weblog and Open Source Projects of Florian Wolters
+ * @version      GIT: $Id$
+ * @package      xhtml-css
+ * @author       Florian Wolters <florian.wolters.85@googlemail.com>
+ * @copyright    2012 Florian Wolters
+ * @cssdoc       version 1.0-pre
+ * @license      http://gnu.org/licenses/lgpl.txt GNU Lesser General Public License
+ * @link         http://github.com/FlorianWolters/jekyll-bootstrap-theme
+ * @media        all
+ * @valid        true
+ */
+
+body {
+    font-family: Helvetica, Arial, Freesans, clean, sans-serif;
+    padding:1em;
+    margin:auto;
+    max-width:42em;
+    background:#fefefe;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-weight: bold;
+}
+
+h1 {
+    color: #000000;
+    font-size: 28px;
+}
+
+h2 {
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
+    border-bottom-color: #CCCCCC;
+    color: #000000;
+    font-size: 24px;
+}
+
+h3 {
+    font-size: 18px;
+}
+
+h4 {
+    font-size: 16px;
+}
+
+h5 {
+    font-size: 14px;
+}
+
+h6 {
+    color: #777777;
+    background-color: inherit;
+    font-size: 14px;
+}
+
+hr {
+    height: 0.2em;
+    border: 0;
+    color: #CCCCCC;
+    background-color: #CCCCCC;
+}
+
+p, blockquote, ul, ol, dl, li, table, pre {
+    margin: 15px 0;
+}
+
+code, pre {
+    border-radius: 3px;
+    background-color: #F8F8F8;
+    color: inherit;
+}
+
+code {
+    border-top-width: 1px;
+    border-top-style: solid;
+    border-top-color: #EAEAEA;
+    border-right-width: 1px;
+    border-right-style: solid;
+    border-right-color: #EAEAEA;
+    border-left-width: 1px;
+    border-left-style: solid;
+    border-left-color: #EAEAEA;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
+    border-bottom-color: #EAEAEA;
+    margin: 0 2px;
+    padding: 0 5px;
+}
+
+pre {
+    border-top-width: 1px;
+    border-top-style: solid;
+    border-top-color: #CCCCCC;
+    border-right-width: 1px;
+    border-right-style: solid;
+    border-right-color: #CCCCCC;
+    border-left-width: 1px;
+    border-left-style: solid;
+    border-left-color: #CCCCCC;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
+    border-bottom-color: #CCCCCC;
+    line-height: 1.25em;
+    overflow: auto;
+    padding: 6px 10px;
+}
+
+pre > code {
+    border: 0;
+    margin: 0;
+    padding: 0;
+}
+
+a, a:visited {
+    color: #4183C4;
+    background-color: inherit;
+    text-decoration: none;
+}
+
+blockquote {
+  background: #f9f9f9;
+    border-left-width: 5px;
+    border-left-style: solid;
+    border-left-color: #88c;
+    margin: 1.5em 10px;
+  padding: 0.5em 10px;
+  quotes: "\201C""\201D""\2018""\2019";
+}
+
+/* Added for tables */
+table {
+	font-family: verdana,arial,sans-serif;
+	font-size:11px;
+	color:#333333;
+	border-width: 1px;
+	border-color: #666666;
+	border-collapse: collapse;
+}
+table th {
+	border-width: 1px;
+	padding: 8px;
+	border-style: solid;
+	border-color: #666666;
+	background-color: #dedede;
+}
+table td {
+  border-width: 1px;
+  padding: 8px;
+  border-style: solid;
+  border-color: #666666;
+  background-color: #ffffff;
+}


### PR DESCRIPTION
Please consider my changes to support https://help.github.com/articles/github-flavored-markdown/ and other more advanced MD. I switch to the PegDown parser, and also upgrades version number and require Java1.8.
